### PR TITLE
升级 javax.mail:mail 依赖

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>javax.mail-api</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
             <version>1.6.0</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
     <dependencies>
         <dependency>
             <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
-            <version>1.5.0-b01</version>
+            <artifactId>javax.mail-api</artifactId>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.mitchellbosecke</groupId>


### PR DESCRIPTION
项目 `javax.mail:mail` 已被弃用，并被移动到了 `javax.mail:javax.mail-api`，原先的项目仅因兼容性原因而保留。

详见：
- https://mvnrepository.com/artifact/javax.mail/mail
- https://mvnrepository.com/artifact/com.sun.mail/javax.mail